### PR TITLE
Add delete budget api endpoint

### DIFF
--- a/server/budgettracker.business/Api/BudgetApi.cs
+++ b/server/budgettracker.business/Api/BudgetApi.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using budgettracker.data.Repositories;
 using budgettracker.business.Api.Converters;
 using budgettracker.business.Api.Contracts.BudgetApi;
+using budgettracker.business.Api.Contracts.BudgetApi.DeleteBudgets;
 using budgettracker.data.Exceptions;
 using budgettracker.common;
 
@@ -36,7 +37,7 @@ namespace budgettracker.business.Api
 
         public async Task<ApiResponse> CreateBudget(ApiRequest request)
         {
-            Authenticate(request);           
+            Authenticate(request);
 
             CreateBudgetArgumentApiContract budgetRequest = request.Arguments<CreateBudgetArgumentApiContract>();
 
@@ -61,6 +62,26 @@ namespace budgettracker.business.Api
             CreateBudgetResponseContract response = _budgetConverter.ToResponseContract(newBudget);
 
             return new ApiResponse(response);
+        }
+
+        public async Task<ApiResponse> DeleteBudgets(ApiRequest request)
+        {
+            Authenticate(request);
+
+            ApiResponse response = null;
+
+            DeleteBudgetArgumentsApiContract deleteArgs = request.Arguments<DeleteBudgetArgumentsApiContract>();
+            try
+            {
+                await _budgetRepository.DeleteBudgets(deleteArgs.BudgetIds);
+                response = new ApiResponse();
+            }
+            catch (RepositoryException e)
+            {
+                response = new ApiResponse(e.Message);
+            }
+
+            return response;
         }
     }
 }

--- a/server/budgettracker.business/Api/Contracts/BudgetApi/DeleteBudgets/DeleteBudgetArgumentsApiContract.cs
+++ b/server/budgettracker.business/Api/Contracts/BudgetApi/DeleteBudgets/DeleteBudgetArgumentsApiContract.cs
@@ -1,0 +1,12 @@
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace budgettracker.business.Api.Contracts.BudgetApi.DeleteBudgets
+{
+    public class DeleteBudgetArgumentsApiContract : IApiContract
+    {
+        [JsonProperty("budget-ids")]
+        public List<Guid> BudgetIds { get; set; }
+    }
+}

--- a/server/budgettracker.business/Api/Contracts/Responses/ApiResponse.cs
+++ b/server/budgettracker.business/Api/Contracts/Responses/ApiResponse.cs
@@ -5,6 +5,16 @@ namespace budgettracker.business.Api.Contracts.Responses
 {
     public class ApiResponse
     {
+        /// <summary>
+        /// <p>
+        /// Instantiate an empty response. This designates that the request was
+        /// good and succeeded but no data was provided to be returned. Think of
+        /// this as a void return value.
+        /// </p>
+        /// </summary>
+        public ApiResponse()
+        {}
+            
         public ApiResponse(IApiContract data)
         {
             Response = data;
@@ -17,7 +27,7 @@ namespace budgettracker.business.Api.Contracts.Responses
 
         [JsonProperty("response", NullValueHandling=NullValueHandling.Ignore)]
         public IApiContract Response { get; set; }
-        
+
         [JsonProperty("error", NullValueHandling=NullValueHandling.Ignore)]
         public string Error { get; set; }
     }

--- a/server/budgettracker.business/Api/Interfaces/IBudgetApi.cs
+++ b/server/budgettracker.business/Api/Interfaces/IBudgetApi.cs
@@ -9,11 +9,21 @@ namespace budgettracker.business.Api.Interfaces
     {
         /// <summary>
         /// <p>
-        /// Creates a new budget in the database. Will return the givne budget 
+        /// Creates a new budget in the database. Will return the givne budget
         /// if created sucessfully otherwise will throw an exception.
         /// </p>
         /// </summary>
         /// <param name="request"> <see cref="ApiRequest"/> </param>
         Task<ApiResponse> CreateBudget(ApiRequest request);
+
+        /// <summary>
+        /// <p>
+        /// Deletes all Budgets that match the given ids. All ids that do not
+        /// match a Budget record or couldn't be deleted will be returned in an
+        /// error message. All budgets that can be deleted will be deleted
+        /// before the error message is returned.
+        /// </p>
+        /// </summary>
+        Task<ApiResponse> DeleteBudgets(ApiRequest request);
     }
 }

--- a/server/budgettracker.data/Repositories/BudgetRepository.cs
+++ b/server/budgettracker.data/Repositories/BudgetRepository.cs
@@ -3,8 +3,11 @@ using budgettracker.data.Converters;
 using budgettracker.data.Exceptions;
 using budgettracker.data.Models;
 using budgettracker.data.Repositories.Interfaces;
+using Microsoft.EntityFrameworkCore;
 using System;
+using System.Collections.Generic;
 using System.Data.Common;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace budgettracker.data.Repositories
@@ -30,12 +33,33 @@ namespace budgettracker.data.Repositories
                 await _dbContext.Budgets.AddAsync(newBudget);
                 int recordSaved = await _dbContext.SaveChangesAsync();
 
-                if(recordSaved != 1) 
+                if(recordSaved != 1)
                 {
                     throw new RepositoryException("Created " + recordSaved + " budget(s) when only 1 should have been created");
                 }
             }
-            return _budgetConverter.ToBusinessModel(newBudget);  
+            return _budgetConverter.ToBusinessModel(newBudget);
+        }
+
+        public async Task DeleteBudgets(List<Guid> Ids)
+        {
+            List<BudgetModel> toDelete = await _dbContext.Budgets.Where(b => Ids.Contains(b.Id)).ToListAsync();
+            List<Guid> nonExistant = Ids.Where(id => !toDelete.Select(b => b.Id).Contains(id)).ToList();
+            List<Guid> erroredBudgets = nonExistant;
+
+            _dbContext.RemoveRange(toDelete);
+            if (await _dbContext.SaveChangesAsync() < toDelete.Count())
+            {
+                List<Guid> notDeleted = await (from b in _dbContext.Budgets
+                                                where Ids.Contains(b.Id)
+                                                select b.Id).ToListAsync();
+                erroredBudgets.AddRange(notDeleted);
+            }
+            if (erroredBudgets.Any())
+            {
+                string errorIds = String.Join(",", erroredBudgets.ToArray());
+                throw new RepositoryException("NOT_DELETED:" + errorIds);
+            }
         }
     }
 }

--- a/server/budgettracker.data/Repositories/Interfaces/IBudgetRepository.cs
+++ b/server/budgettracker.data/Repositories/Interfaces/IBudgetRepository.cs
@@ -1,5 +1,7 @@
-using System.Threading.Tasks;
 using budgettracker.common.Models;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace budgettracker.data.Repositories.Interfaces
 {
@@ -7,12 +9,23 @@ namespace budgettracker.data.Repositories.Interfaces
     {
         /// <summary>
         /// <p>
-        /// Saves the new budget to the database will return the newly created budget 
-        /// model but will throw exceptions if something fails will be caught in 
+        /// Saves the new budget to the database will return the newly created budget
+        /// model but will throw exceptions if something fails will be caught in
         /// <see cref="BudgetApi"/>
         /// </p>
         /// </summary>
         /// <param name="budget"><see cref="Budget"/></param>
         Task<Budget> CreateBudget(Budget budget);
+
+        /// <summary>
+        /// <p>
+        /// Deletes all Budgets that match the given ids. All ids that do not
+        /// match a Budget record or couldn't be deleted will be returned in a
+        /// <see cref="budgettracker.data.Exceptions.RepositoryException" />.
+        /// This error will not be thrown until all budgets that can be deleted
+        /// have been deleted.
+        /// </p>
+        /// </summary>
+        Task DeleteBudgets(List<Guid> Ids);
     }
 }

--- a/server/budgettracker.web/Controllers/BudgetApiController.cs
+++ b/server/budgettracker.web/Controllers/BudgetApiController.cs
@@ -15,7 +15,7 @@ namespace budgettracker.web.Controllers
     [ApiController]
     public class BudgetApiController : ControllerBase
     {
-        
+
         private readonly IBudgetApi _budgetApi;
 
         public BudgetApiController(IBudgetApi budgetApi)
@@ -28,12 +28,25 @@ namespace budgettracker.web.Controllers
         {
             try
             {
-                return new JsonResult(await _budgetApi.CreateBudget(request));    
+                return new JsonResult(await _budgetApi.CreateBudget(request));
             }
-            catch (AuthenticationException) 
+            catch (AuthenticationException)
             {
                 return Forbid();
-            }            
+            }
+        }
+
+        [HttpPost("delete")]
+        public async Task<IActionResult> DeleteBudgets(ApiRequest request)
+        {
+            try
+            {
+                return new JsonResult(await _budgetApi.DeleteBudgets(request));    
+            }
+            catch (AuthenticationException)
+            {
+                return Forbid();
+            }
         }
     }
 }


### PR DESCRIPTION
Adds an endpoint to delete Budgets

I have it permanently deleting budgets instead of marking them as deleted. I did this because there's really no reason to use them after they're deleted.