### PR TITLE
Add API endpoint to fetch a budget tree

### DIFF
--- a/server/BudgetTracker.Business/Api/Contracts/BudgetApi/BudgetTree/FetchBudgetTreeArgumentsApiContract.cs
+++ b/server/BudgetTracker.Business/Api/Contracts/BudgetApi/BudgetTree/FetchBudgetTreeArgumentsApiContract.cs
@@ -1,0 +1,12 @@
+using BudgetTracker.Business.Api.Contracts;
+using Newtonsoft.Json;
+using System;
+
+namespace BudgetTracker.Business.Api.Contracts.BudgetApi.BudgetTree
+{
+    public class FetchBudgetTreeArgumentsApiContract : ApiContract
+    {
+        [JsonProperty("root-budget-id")]
+        public Guid RootBudgetId { get; set; }
+    }
+}

--- a/server/BudgetTracker.Business/Api/Contracts/BudgetApi/BudgetTree/FetchBudgetTreeArgumentsApiContract.cs
+++ b/server/BudgetTracker.Business/Api/Contracts/BudgetApi/BudgetTree/FetchBudgetTreeArgumentsApiContract.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace BudgetTracker.Business.Api.Contracts.BudgetApi.BudgetTree
 {
-    public class FetchBudgetTreeArgumentsApiContract : ApiContract
+    public class FetchBudgetTreeArgumentsApiContract : IApiContract
     {
         [JsonProperty("root-budget-id")]
         public Guid RootBudgetId { get; set; }

--- a/server/BudgetTracker.Business/Api/Contracts/BudgetApi/GetBudget/GetBudgetArgumentApiContract.cs
+++ b/server/BudgetTracker.Business/Api/Contracts/BudgetApi/GetBudget/GetBudgetArgumentApiContract.cs
@@ -1,6 +1,7 @@
+using BudgetTracker.Business.Api.Contracts;
 using Newtonsoft.Json;
 
-namespace budgettracker.business.Api.Contracts.BudgetApi.GetBudget
+namespace BudgetTracker.Business.Api.Contracts.BudgetApi.GetBudget
 {
     public class GetBudgetArgumentApiContract : IApiContract
     {

--- a/server/BudgetTracker.Business/Api/Contracts/BudgetApi/GetBudget/GetBudgetRequestContract.cs
+++ b/server/BudgetTracker.Business/Api/Contracts/BudgetApi/GetBudget/GetBudgetRequestContract.cs
@@ -1,7 +1,7 @@
 using System;
 using Newtonsoft.Json;
 
-namespace budgettracker.business.Api.Contracts.BudgetApi.GetBudget
+namespace BudgetTracker.Business.Api.Contracts.BudgetApi.GetBudget
 {
     public class GetBudgetRequestContract : IApiContract
     {

--- a/server/BudgetTracker.Business/Api/Converters/BudgetConverters/GeneralBudgetApiConverter.cs
+++ b/server/BudgetTracker.Business/Api/Converters/BudgetConverters/GeneralBudgetApiConverter.cs
@@ -76,7 +76,7 @@ namespace BudgetTracker.Business.Api.Converters.BudgetConverters
 
         public static BudgetResponseContract ToGeneralResponseContract(Budget model)
         {
-            return new BudgetResponseContract()
+            BudgetResponseContract responseContract = new BudgetResponseContract()
             {
                 Id = model.Id,
                 Name = model.Name,
@@ -85,6 +85,13 @@ namespace BudgetTracker.Business.Api.Converters.BudgetConverters
                 BudgetStart = model.BudgetStart,
                 ParentBudgetId = model.ParentBudgetId
             };
+
+            if (model.SubBudgets != null)
+            {
+                responseContract.SubBudgets = ToGeneralResponseContracts(model.SubBudgets);
+            }
+
+            return responseContract;
         }
 
         public static List<BudgetResponseContract> ToGeneralResponseContracts(List<Budget> budgets)

--- a/server/BudgetTracker.Business/Api/Interfaces/IBudgetApi.cs
+++ b/server/BudgetTracker.Business/Api/Interfaces/IBudgetApi.cs
@@ -51,5 +51,13 @@ namespace BudgetTracker.Business.Api.Interfaces
         /// </p>
         /// </summary>
         Task<ApiResponse> GetRootBudgets(ApiRequest request);
+
+        /// <summary>
+        /// <p>
+        /// Fetches a root budget and it's full tree of sub-budgets and their
+        /// sub budgets recursively.
+        /// </p>
+        /// </summary>
+        Task<ApiResponse> FetchBudgetTree(ApiRequest request);
     }
 }

--- a/server/BudgetTracker.Common/Models/Budget.cs
+++ b/server/BudgetTracker.Common/Models/Budget.cs
@@ -41,6 +41,11 @@ namespace BudgetTracker.Common.Models
         public Guid? ParentBudgetId { get; set; }
 
         /// <summary>
+        /// The parent budget of which this is a sub-budget.
+        /// </summary>
+        public Budget ParentBudget { get; set; }
+
+        /// <summary>
         /// The user that owns this budget.
         /// </summary>
         public User Owner { get; set; }

--- a/server/BudgetTracker.Common/Models/Budget.cs
+++ b/server/BudgetTracker.Common/Models/Budget.cs
@@ -45,6 +45,11 @@ namespace BudgetTracker.Common.Models
         /// </summary>
         public User Owner { get; set; }
 
+        /// <summary>
+        /// Budgets that are children of this budget.
+        /// </summary>
+        public List<Budget> SubBudgets { get; set; }
+
         public override string ToString()
         {
             string str = this.Name + " ($" + this.SetAmount.ToString() + ")";

--- a/server/BudgetTracker.Data/Repositories/BudgetRepository.cs
+++ b/server/BudgetTracker.Data/Repositories/BudgetRepository.cs
@@ -139,7 +139,7 @@ namespace BudgetTracker.Data.Repositories
                 subBudget.ParentBudget = budget;
                 if (recursive)
                 {
-                    await LoadSubBudgets(subBudget);
+                    await LoadSubBudgets(subBudget, recursive);
                 }
             }
             budget.SubBudgets = subBudgets;

--- a/server/BudgetTracker.Data/Repositories/BudgetRepository.cs
+++ b/server/BudgetTracker.Data/Repositories/BudgetRepository.cs
@@ -63,12 +63,13 @@ namespace BudgetTracker.Data.Repositories
         public async Task<Budget> GetBudget(Guid id)
         {
             BudgetModel budget = await _dbContext.Budgets.Where(x => x.Id == id).FirstAsync();
-            if (budget == null) 
+            if (budget == null)
             {
                 throw new RepositoryException("Was not able to find a budget with the id " + id);
             }
-            else 
+            else
             {
+                budget.Duration = await LoadDurationForBudget(budget);
                 return BudgetConverter.ToBusinessModel(budget);
             }
         }
@@ -80,7 +81,7 @@ namespace BudgetTracker.Data.Repositories
             rootBudgets = rootBudgets.Where(b => b.ParentBudgetId == null).ToList();
             foreach (BudgetModel budgetModel in rootBudgets)
             {
-                budgetModel.Duration = await LoadDurationForBudget(budgetModel);
+
             }
             List<Budget> rootBudgetsBusinessModels = BudgetConverter.ToBusinessModels(rootBudgets);
             return rootBudgetsBusinessModels;
@@ -90,6 +91,14 @@ namespace BudgetTracker.Data.Repositories
         {
             BudgetDurationModel duration = await _dbContext.BudgetDurations.SingleAsync(d => d.Id == budget.DurationId);
             return duration;
+        }
+
+        public async Task LoadDurationsForBudgets(List<BudgetModel> budgets)
+        {
+            foreach (BudgetModel budgetModel in budgets)
+            {
+                budgetModel.Duration = await _dbContext.BudgetDurations.SingleAsync(d => d.Id == budgetModel.DurationId);
+            }
         }
 
         public async Task<Budget> UpdateBudget(Budget budget)
@@ -120,6 +129,23 @@ namespace BudgetTracker.Data.Repositories
             }
 
             return BudgetConverter.ToBusinessModel(oldBudget);
+        }
+
+        public async Task LoadSubBudgets(Budget budget, bool recursive=false)
+        {
+            List<BudgetModel> subBudgetsData = await _dbContext.Budgets.Where(b => b.ParentBudgetId.Value == budget.Id).ToListAsync();
+            await LoadDurationsForBudgets(subBudgetsData);
+
+            List<Budget> subBudgets = BudgetConverter.ToBusinessModels(subBudgetsData);
+            foreach (Budget subBudget in subBudgets)
+            {
+                subBudget.ParentBudget = budget;
+                if (recursive)
+                {
+                    await LoadSubBudgets(subBudget);
+                }
+            }
+            budget.SubBudgets = subBudgets;
         }
 
         private BudgetDurationModel GetBudgetDurationUpdated(BudgetDurationModel original, BudgetDurationBase newBudget)

--- a/server/BudgetTracker.Data/Repositories/BudgetRepository.cs
+++ b/server/BudgetTracker.Data/Repositories/BudgetRepository.cs
@@ -79,10 +79,7 @@ namespace BudgetTracker.Data.Repositories
             List<BudgetModel> rootBudgets = await _dbContext.Budgets.Where(b => b.OwnerId == userId).ToListAsync();
             // Have to do this outside of query because EF can't do null checks.
             rootBudgets = rootBudgets.Where(b => b.ParentBudgetId == null).ToList();
-            foreach (BudgetModel budgetModel in rootBudgets)
-            {
-
-            }
+            await LoadDurationsForBudgets(rootBudgets);
             List<Budget> rootBudgetsBusinessModels = BudgetConverter.ToBusinessModels(rootBudgets);
             return rootBudgetsBusinessModels;
         }

--- a/server/BudgetTracker.Data/Repositories/Interfaces/IBudgetRepository.cs
+++ b/server/BudgetTracker.Data/Repositories/Interfaces/IBudgetRepository.cs
@@ -20,12 +20,12 @@ namespace BudgetTracker.Data.Repositories.Interfaces
         /// <summary>
         /// <p>
         /// Updates a budget based off their id, will return the update budget
-        /// modle but will throw an exception if something fails will be caught in 
+        /// modle but will throw an exception if something fails will be caught in
         /// <see cref="BudgetApi"/>
         /// </p>
         /// </summary>
         Task<Budget> UpdateBudget(Budget budget);
-        
+
         /// Deletes all Budgets that match the given ids. All ids that do not
         /// match a Budget record or couldn't be deleted will be returned in a
         /// <see cref="BudgetTracker.Data.Exceptions.RepositoryException" />.
@@ -49,5 +49,13 @@ namespace BudgetTracker.Data.Repositories.Interfaces
         /// </p>
         /// </summary>
         Task<List<Budget>> GetRootBudgets(Guid userId);
+
+        /// <summary>
+        /// <p>
+        /// Fetches the entire tree of sub budgets for the given root budget and
+        /// attaches them to that root budget's SubBudgets property.
+        /// </p>
+        /// </summary>
+        Task LoadBudgetTree(Budget rootBudget);
     }
 }

--- a/server/BudgetTracker.Data/Repositories/Interfaces/IBudgetRepository.cs
+++ b/server/BudgetTracker.Data/Repositories/Interfaces/IBudgetRepository.cs
@@ -52,10 +52,15 @@ namespace BudgetTracker.Data.Repositories.Interfaces
 
         /// <summary>
         /// <p>
-        /// Fetches the entire tree of sub budgets for the given root budget and
-        /// attaches them to that root budget's SubBudgets property.
+        /// Fetches all sub-budgets for the given budget and attaches them to
+        /// that root budget's SubBudgets property.
+        /// </p>
+        /// <p>
+        /// If recursive is true, this will load the sub-budgets for each of
+        /// THOSE sub-budgets and so on and so on until the entire sub-budget
+        /// tree of the given budget has been loaded.
         /// </p>
         /// </summary>
-        Task LoadBudgetTree(Budget rootBudget);
+        Task LoadSubBudgets(Budget budget, bool recursive=false);
     }
 }

--- a/server/BudgetTracker.Web/Controllers/BudgetApiController.cs
+++ b/server/BudgetTracker.Web/Controllers/BudgetApiController.cs
@@ -67,12 +67,12 @@ namespace BudgetTracker.Web.Controllers
         {
             try
             {
-                return new JsonResult(await _budgetApi.UpdateBudget(request));    
+                return new JsonResult(await _budgetApi.UpdateBudget(request));
             }
-            catch (AuthenticationException) 
+            catch (AuthenticationException)
             {
                 return Forbid();
-            }            
+            }
         }
 
         [HttpPost("get")]
@@ -80,12 +80,25 @@ namespace BudgetTracker.Web.Controllers
         {
             try
             {
-                return new JsonResult(await _budgetApi.GetBudget(request));    
+                return new JsonResult(await _budgetApi.GetBudget(request));
             }
-            catch (AuthenticationException) 
+            catch (AuthenticationException)
             {
                 return Forbid();
-            }            
+            }
+        }
+
+        [HttpPost("tree")]
+        public async Task<IActionResult> FetchBudgetTree(ApiRequest request)
+        {
+            try
+            {
+                return new JsonResult(await _budgetApi.FetchBudgetTree(request));
+            }
+            catch (AuthenticationException)
+            {
+                return Forbid();
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #63 
Allows the user to fetch a budget tree from a given root budget.